### PR TITLE
ldap_close is an alias of ldap_unbind

### DIFF
--- a/src/Auth/LdapAuthenticate.php
+++ b/src/Auth/LdapAuthenticate.php
@@ -120,11 +120,6 @@ class LdapAuthenticate extends BaseAuthenticate
         } catch (ErrorException $e) {
             // Do Nothing
         }
-        try {
-            ldap_close($this->ldapConnection);
-        } catch (ErrorException $e) {
-            // Do Nothing
-        }
 
         restore_error_handler();
     }


### PR DESCRIPTION
ldap_close is an alias of ldap_unbind. No need to call the same function twice.

http://us2.php.net/manual/en/function.ldap-close.php