### PR TITLE
Extending options for ldap_search params

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,11 @@ Setup the authentication class settings
             ],
             'authError' => 'Insufficient privileges to view requested resources. Please login to continue!',
             'authenticate' => [
-                'Ldap.Ldap' => [
+                'Ldap.Ldap' => Configure::read('Ldap') + [
                     'fields' => [
                         'username' => 'username',
                         'password' => 'password'
                     ],
-                    'port' => Configure::read('Ldap.port'),
-                    'host' => Configure::read('Ldap.host'),
-                    'domain' => Configure::read('Ldap.domain'),
-                    'baseDN' => Configure::read('Ldap.baseDN'),
-                    'bindDN' => Configure::read('Ldap.bindDN'),
-                    'search' => Configure::read('Ldap.search'),
-                    'errors' => Configure::read('Ldap.errors'),
-                    'logErrors' => Configure::read('Ldap.logErrors'),
-                    'options' => Configure::read('Ldap.options'),
                     'flash' => [
                         'key' => 'ldap',
                         'element' => 'Flash/error',
@@ -107,7 +98,10 @@ config/app.php:
         },
         //'host' => '127.0.0.1',
         'port' => 389,
-        'search' => 'UserPrincipalName',
+        'search' => function($username) {
+            return '(UserPrincipalName=' . $username . ')';
+        },
+        'searchAttributes' => ['*', 'memberof'],
         'baseDN' => function($username, $domain) {
             if (strpos($username, $domain) !== false) {
                 $baseDN = 'OU=example,DC=domain,DC=local';

--- a/src/Auth/LdapAuthenticate.php
+++ b/src/Auth/LdapAuthenticate.php
@@ -163,7 +163,13 @@ class LdapAuthenticate extends BaseAuthenticate
         try {
             $ldapBind = ldap_bind($this->ldapConnection, isset($this->_config['bindDN']) ? $this->_config['bindDN']($username, $this->_config['domain']) : $username, $password);
             if ($ldapBind === true) {
-                $searchResults = ldap_search($this->ldapConnection, $this->_config['baseDN']($username, $this->_config['domain']), '(' . $this->_config['search'] . '=' . $username . ')');
+                debug(!empty($this->_config['searchAttributes']) ? (is_array($this->_config['searchAttributes']) ? $this->_config['searchAttributes'] : [$this->_config['searchAttributes']]) : ['*']);
+                $searchResults = ldap_search(
+                    $this->ldapConnection,
+                    $this->_config['baseDN']($username, $this->_config['domain']),
+                    (isset($this->_config['search']) && is_callable($this->_config['search'])) ? $this->_config['search']($username) : ('(' . $this->_config['search'] . '=' . $username . ')'),
+                    !empty($this->_config['searchAttributes']) ? (is_array($this->_config['searchAttributes']) ? $this->_config['searchAttributes'] : [$this->_config['searchAttributes']]) : ['*']
+                );
                 $entry = ldap_first_entry($this->ldapConnection, $searchResults);
 
                 return ldap_get_attributes($this->ldapConnection, $entry);


### PR DESCRIPTION
Adding additional search and search return attributes options for ldap_search.  This allows much more granular configuration of the LDAP search filter and return attributes options (for cases where memberof might not be returned by default or you want to limit the attributes returned)